### PR TITLE
bugfix/TESB-30463: correct xstream-bundle-version

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -743,7 +743,8 @@
     <xpp3-bundle-version>1.1.4c_7</xpp3-bundle-version>
     <xpp3-version>1.1.4c</xpp3-version>
     <xsdlib-version>2013.2</xsdlib-version>
-    <xstream-bundle-version>1.4.11_1</xstream-bundle-version>
+    <xstream-bundle-version>1.4.11.1_1</xstream-bundle-version>
+    <xstream-java8-bundle-version>1.4.11_1</xstream-java8-bundle-version>
     <xstream-version>1.4.11.1</xstream-version>
     <xom-version>1.2.5</xom-version>
     <zendesk-client-version>0.6.2</zendesk-client-version>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -743,7 +743,7 @@
     <xpp3-bundle-version>1.1.4c_7</xpp3-bundle-version>
     <xpp3-version>1.1.4c</xpp3-version>
     <xsdlib-version>2013.2</xsdlib-version>
-    <xstream-bundle-version>1.4.11.1_1</xstream-bundle-version>
+    <xstream-bundle-version>1.4.11_1</xstream-bundle-version>
     <xstream-version>1.4.11.1</xstream-version>
     <xom-version>1.2.5</xom-version>
     <zendesk-client-version>0.6.2</zendesk-client-version>

--- a/platforms/karaf/features/src/main/resources/features.xml
+++ b/platforms/karaf/features/src/main/resources/features.xml
@@ -358,7 +358,7 @@
     <details>Not working well in OSGi atm, requires the runtime to provide sun.nio.ch, sun.misc, sun.reflect, com.sun.jdi.connect.spi, com.sun.nio.file</details>
     <feature version='${upstream.version}'>camel-core</feature>
     <bundle dependency='true'>mvn:org.xerial.snappy/snappy-java/${snappy-version}</bundle>
-    <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xstream-java8/${xstream-bundle-version}</bundle>
+    <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xstream-java8/${xstream-java8-bundle-version}</bundle>
     <bundle dependency='true'>mvn:net.java.dev.jna/jna/${jna-version}</bundle>
     <bundle dependency='true'>mvn:net.java.dev.jna/jna-platform/${jna-version}</bundle>
     <bundle dependency='true'>mvn:commons-cli/commons-cli/${commons-cli-version}</bundle>


### PR DESCRIPTION
try to upgrade camel to 2.25.2.
and met with issue: [CAMEL-15705] camel 2.x - camel-chronicle feature install failed due to xstream-java8 version - ASF JIRA
there is no 1.4.11.1_1 for xstream-bundle-version, but only 1.4.11_1