### PR TITLE
bugfix(TESB-32508): upgrade swagger version to 1.6.2, due to jackson …

### DIFF
--- a/platforms/karaf/features/src/main/resources/features.xml
+++ b/platforms/karaf/features/src/main/resources/features.xml
@@ -1990,10 +1990,10 @@
     <bundle dependency='true'>mvn:com.fasterxml.jackson.module/jackson-module-jsonSchema/${jackson2.tesb.version}</bundle>
     <bundle dependency='true'>mvn:org.apache.commons/commons-lang3/${commons-lang3-version}</bundle>
     <bundle dependency='true'>mvn:com.google.guava/guava/${swagger-java-guava-version}</bundle>
-    <bundle dependency='true'>mvn:io.swagger/swagger-core/${swagger-java-version}</bundle>
-    <bundle dependency='true'>mvn:io.swagger/swagger-annotations/${swagger-java-version}</bundle>
-    <bundle dependency='true'>mvn:io.swagger/swagger-models/${swagger-java-version}</bundle>
-    <bundle dependency='true'>mvn:io.swagger/swagger-jaxrs/${swagger-java-version}</bundle>
+    <bundle dependency='true'>mvn:io.swagger/swagger-core/${swagger-java.tesb.version}</bundle>
+    <bundle dependency='true'>mvn:io.swagger/swagger-annotations/${swagger-java.tesb.version}</bundle>
+    <bundle dependency='true'>mvn:io.swagger/swagger-models/${swagger-java.tesb.version}</bundle>
+    <bundle dependency='true'>mvn:io.swagger/swagger-jaxrs/${swagger-java.tesb.version}</bundle>
     <bundle dependency='true'>wrap:mvn:io.swagger/swagger-parser/${swagger-java-parser-version}</bundle>
     <bundle>mvn:org.apache.camel/camel-rest-swagger/${upstream.version}</bundle>
   </feature>
@@ -2371,10 +2371,10 @@
     <bundle dependency='true'>mvn:javax.validation/validation-api/${validation-1-api-version}</bundle>
     <bundle dependency='true'>mvn:org.apache.commons/commons-lang3/${commons-lang3-version}</bundle>
     <bundle dependency='true'>mvn:com.google.guava/guava/${swagger-java-guava-version}</bundle>
-    <bundle dependency='true'>mvn:io.swagger/swagger-core/${swagger-java-version}</bundle>
-    <bundle dependency='true'>mvn:io.swagger/swagger-annotations/${swagger-java-version}</bundle>
-    <bundle dependency='true'>mvn:io.swagger/swagger-models/${swagger-java-version}</bundle>
-    <bundle dependency='true'>mvn:io.swagger/swagger-jaxrs/${swagger-java-version}</bundle>
+    <bundle dependency='true'>mvn:io.swagger/swagger-core/${swagger-java.tesb.version}</bundle>
+    <bundle dependency='true'>mvn:io.swagger/swagger-annotations/${swagger-java.tesb.version}</bundle>
+    <bundle dependency='true'>mvn:io.swagger/swagger-models/${swagger-java.tesb.version}</bundle>
+    <bundle dependency='true'>mvn:io.swagger/swagger-jaxrs/${swagger-java.tesb.version}</bundle>
     <bundle dependency='true'>wrap:mvn:io.swagger/swagger-parser/${swagger-java-parser-version}</bundle>
     <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.reflections/${reflections-bundle-version}</bundle>
     <bundle>mvn:org.apache.camel/camel-swagger-java/${upstream.version}</bundle>

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,7 @@
     <dom4j-bundle.tesb.version>2.1.3_1</dom4j-bundle.tesb.version>
     <hikaricp.tesb.version>2.4.13</hikaricp.tesb.version>
     <quartz2.tesb.version>2.3.2</quartz2.tesb.version>
+    <swagger-java.tesb.version>1.6.2</swagger-java.tesb.version>
 
     <!-- enforce to require using at least this maven version -->
     <maven-enforcer-require-maven-version>3.2.5</maven-enforcer-require-maven-version>
@@ -231,6 +232,7 @@
               <dom4j-bundle.tesb.version>${dom4j-bundle.tesb.version}</dom4j-bundle.tesb.version>
               <hikaricp.tesb.version>${hikaricp.tesb.version}</hikaricp.tesb.version>
               <quartz2.tesb.version>${quartz2.tesb.version}</quartz2.tesb.version>
+              <swagger-java.tesb.version>${swagger-java.tesb.version}</swagger-java.tesb.version>
             </properties>
           </configuration>
           <executions>


### PR DESCRIPTION
…version upgrade to 2.11.4

No repo feature version upgrade as part of the same patch