### PR TITLE
bugfix(APPINT-32676): cREST overwrite Content-Language header on runt…

### DIFF
--- a/Jenkinsfile.talend
+++ b/Jenkinsfile.talend
@@ -1,5 +1,5 @@
 @Library('esb') _
 
 Fork(
-        MVN_MODULES: 'org.apache.camel:camel-mqtt,org.apache.camel:camel-saxon,org.apache.camel.karaf:apache-camel'
+        MVN_MODULES: 'org.apache.camel:camel-mqtt,org.apache.camel:camel-saxon,org.apache.camel:camel-cxf,org.apache.camel.karaf:apache-camel'
 )

--- a/components/camel-cxf/pom.xml
+++ b/components/camel-cxf/pom.xml
@@ -30,8 +30,10 @@
   <packaging>jar</packaging>
   <name>Camel :: CXF</name>
   <description>Camel CXF support</description>
+  <version>${revision}</version>
 
   <properties>
+    <revision>${camel-cxf.tesb.version}</revision>
     <camel.osgi.import>
       !org.springframework.boot.*,
       !org.springframework.context.annotation.*;resolution:=optional,

--- a/components/camel-cxf/src/main/java/org/apache/camel/component/cxf/jaxrs/CxfRsBinding.java
+++ b/components/camel-cxf/src/main/java/org/apache/camel/component/cxf/jaxrs/CxfRsBinding.java
@@ -28,7 +28,7 @@ import org.apache.cxf.message.Exchange;
 /**
  * Interface to bind between Camel and CXF exchange for RESTful resources.
  *
- * @version 
+ * @version
  */
 public interface CxfRsBinding {
 
@@ -116,4 +116,20 @@ public interface CxfRsBinding {
      * @return the {@link Entity} to use
      */
     Entity<Object> bindCamelMessageToRequestEntity(Object body, org.apache.camel.Message camelMessage, org.apache.camel.Exchange camelExchange) throws Exception;
+
+    /**
+     * Bind the Camel message to a request {@link Entity} that gets passed to
+     * {@link AsyncInvoker#method(java.lang.String, javax.ws.rs.client.Entity, javax.ws.rs.client.InvocationCallback)}.
+     *
+     * @param  camelMessage  the source message
+     * @param  camelExchange the Camel exchange
+     * @param  body          the message body
+     * @param  webClient     the CXF JAXRS WebClient
+     * @throws Exception     can be thrown if error in the binding process
+     * @return               the {@link Entity} to use
+     */
+    Entity<Object> bindCamelMessageToRequestEntity(
+            Object body, org.apache.camel.Message camelMessage, org.apache.camel.Exchange camelExchange,
+            org.apache.cxf.jaxrs.client.WebClient webClient)
+            throws Exception;
 }

--- a/components/camel-cxf/src/main/java/org/apache/camel/component/cxf/jaxrs/CxfRsProducer.java
+++ b/components/camel-cxf/src/main/java/org/apache/camel/component/cxf/jaxrs/CxfRsProducer.java
@@ -171,7 +171,7 @@ public class CxfRsProducer extends DefaultProducer implements AsyncProcessor {
         }
 
         //Build message entity
-        Entity<Object> entity = binding.bindCamelMessageToRequestEntity(body, inMessage, exchange);
+        Entity<Object> entity = binding.bindCamelMessageToRequestEntity(body, inMessage, exchange, client);
 
         // handle cookies
         CookieHandler cookieHandler = ((CxfRsEndpoint)getEndpoint()).getCookieHandler();

--- a/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/jaxrs/CxfRsBindingConfigurationSelectionTest.java
+++ b/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/jaxrs/CxfRsBindingConfigurationSelectionTest.java
@@ -28,21 +28,22 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.cxf.CXFTestSupport;
 import org.apache.camel.impl.JndiRegistry;
 import org.apache.camel.test.junit4.CamelTestSupport;
+import org.apache.cxf.jaxrs.client.WebClient;
 import org.junit.Test;
 
 /**
- * Tests different binding configuration options of the CXFRS consumer. 
+ * Tests different binding configuration options of the CXFRS consumer.
  */
 public class CxfRsBindingConfigurationSelectionTest extends CamelTestSupport {
-    
+
     private static final String RESOURCE_CLASS = "resourceClasses=org.apache.camel.component.cxf.jaxrs.simplebinding.testbean.CustomerServiceResource";
-    private static final String CXF_RS_ENDPOINT_URI_CUSTOM = String.format("cxfrs://http://localhost:%s/CxfRsConsumerTest/rest?bindingStyle=Custom&", CXFTestSupport.getPort2()) 
+    private static final String CXF_RS_ENDPOINT_URI_CUSTOM = String.format("cxfrs://http://localhost:%s/CxfRsConsumerTest/rest?bindingStyle=Custom&", CXFTestSupport.getPort2())
             + RESOURCE_CLASS + "&binding=#binding";
-    private static final String CXF_RS_ENDPOINT_URI_SIMPLE = String.format("cxfrs://http://localhost:%s/CxfRsConsumerTest/rest?bindingStyle=SimpleConsumer&", CXFTestSupport.getPort1()) 
+    private static final String CXF_RS_ENDPOINT_URI_SIMPLE = String.format("cxfrs://http://localhost:%s/CxfRsConsumerTest/rest?bindingStyle=SimpleConsumer&", CXFTestSupport.getPort1())
             + RESOURCE_CLASS;
     private static final String CXF_RS_ENDPOINT_URI_DEFAULT = String.format("cxfrs://http://localhost:%s/CxfRsConsumerTest/rest?bindingStyle=Default&", CXFTestSupport.getPort3()) + RESOURCE_CLASS;
     private static final String CXF_RS_ENDPOINT_URI_NONE = String.format("cxfrs://http://localhost:%s/CxfRsConsumerTest/rest?", CXFTestSupport.getPort4()) + RESOURCE_CLASS;
-    
+
     @Test
     public void testCxfRsBindingConfiguration() {
         // check binding styles
@@ -50,18 +51,18 @@ public class CxfRsBindingConfigurationSelectionTest extends CamelTestSupport {
         assertEquals(BindingStyle.SimpleConsumer, endpointForRouteId("simple").getBindingStyle());
         assertEquals(BindingStyle.Default, endpointForRouteId("default").getBindingStyle());
         assertEquals(BindingStyle.Default, endpointForRouteId("none").getBindingStyle());
-        
+
         // check binding implementations
         assertEquals(DummyCxfRsBindingImplementation.class, endpointForRouteId("custom").getBinding().getClass());
         assertEquals(SimpleCxfRsBinding.class, endpointForRouteId("simple").getBinding().getClass());
         assertEquals(DefaultCxfRsBinding.class, endpointForRouteId("default").getBinding().getClass());
         assertEquals(DefaultCxfRsBinding.class, endpointForRouteId("default").getBinding().getClass());
     }
-    
+
     private CxfRsEndpoint endpointForRouteId(String routeId) {
         return (CxfRsEndpoint) context.getRoute(routeId).getConsumer().getEndpoint();
     }
-    
+
     @Override
     protected JndiRegistry createRegistry() throws Exception {
         JndiRegistry answer = super.createRegistry();
@@ -72,23 +73,23 @@ public class CxfRsBindingConfigurationSelectionTest extends CamelTestSupport {
     protected RouteBuilder createRouteBuilder() throws Exception {
         return new RouteBuilder() {
             public void configure() {
-                
+
                 from(CXF_RS_ENDPOINT_URI_CUSTOM).routeId("custom")
                     .to("log:foo");
-                
+
                 from(CXF_RS_ENDPOINT_URI_SIMPLE).routeId("simple")
                     .to("log:foo");
-                
+
                 from(CXF_RS_ENDPOINT_URI_DEFAULT).routeId("default")
                     .to("log:foo");
-                
+
                 from(CXF_RS_ENDPOINT_URI_NONE).routeId("none")
                     .to("log:foo");
-                
+
             }
         };
     }
-    
+
     private final class DummyCxfRsBindingImplementation implements CxfRsBinding {
         @Override
         public void populateExchangeFromCxfRsRequest(org.apache.cxf.message.Exchange cxfExchange, Exchange camelExchange, Method method, Object[] paramArray) {
@@ -121,6 +122,14 @@ public class CxfRsBindingConfigurationSelectionTest extends CamelTestSupport {
 
         @Override
         public MultivaluedMap<String, String> bindCamelHeadersToRequestHeaders(Map<String, Object> camelHeaders, Exchange camelExchange) throws Exception {
+            return null;
+        }
+
+        @Override
+        public Entity<Object> bindCamelMessageToRequestEntity(
+                Object body, Message camelMessage,
+                Exchange camelExchange, WebClient webClient)
+                throws Exception {
             return null;
         }
     }

--- a/platforms/karaf/features/src/main/resources/features.xml
+++ b/platforms/karaf/features/src/main/resources/features.xml
@@ -473,7 +473,7 @@
     <feature version='${cxf-version-range}'>cxf-features-logging</feature>
     <bundle>mvn:org.apache.camel/camel-http-common/${upstream.version}</bundle>
     <bundle>mvn:org.apache.camel/camel-cxf-transport/${upstream.version}</bundle>
-    <bundle>mvn:org.apache.camel/camel-cxf/${upstream.version}</bundle>
+    <bundle>mvn:org.apache.camel/camel-cxf/${camel-cxf.tesb.version}</bundle>
   </feature>
   <feature name='camel-digitalocean' version='${upstream.version}' resolver='(obr)' start-level='50'>
     <feature version='${upstream.version}'>camel-core</feature>

--- a/pom.xml
+++ b/pom.xml
@@ -41,11 +41,12 @@
 
   <properties>
     <upstream.version>2.23.1</upstream.version>
-    <apache-camel.features.tesb.version>2.23.1.tesb4</apache-camel.features.tesb.version>
+    <apache-camel.features.tesb.version>2.23.1.tesb5</apache-camel.features.tesb.version>
     <camel-core.tesb.version>2.23.1.tesb2</camel-core.tesb.version>
     <camel.mqtt.tesb.version>2.23.1.tesb1</camel.mqtt.tesb.version>
     <tdm-saxon.tesb.version>9.7.0.211</tdm-saxon.tesb.version>
     <camel-saxon.tesb.version>2.23.1.tesb1</camel-saxon.tesb.version>
+    <camel-cxf.tesb.version>2.23.1.tesb1</camel-cxf.tesb.version>
 
     <!-- enforce to require using at least this maven version -->
     <maven-enforcer-require-maven-version>3.2.5</maven-enforcer-require-maven-version>

--- a/pom.xml
+++ b/pom.xml
@@ -214,10 +214,12 @@
             <properties>
               <revision>${revision}</revision>
               <upstream.version>${upstream.version}</upstream.version>
-              <camel.mqtt.tesb.version>${camel.mqtt.tesb.version}</camel.mqtt.tesb.version>
+              <apache-camel.features.tesb.version>${apache-camel.features.tesb.version}</apache-camel.features.tesb.version>
               <camel-core.tesb.version>${camel-core.tesb.version}</camel-core.tesb.version>
+              <camel.mqtt.tesb.version>${camel.mqtt.tesb.version}</camel.mqtt.tesb.version>
               <tdm-saxon.tesb.version>${tdm-saxon.tesb.version}</tdm-saxon.tesb.version>
               <camel-saxon.tesb.version>${camel-saxon.tesb.version}</camel-saxon.tesb.version>
+              <camel-cxf.tesb.version>${camel-cxf.tesb.version}</camel-cxf.tesb.version>
               <!-- ADD HERE ALL THE CUSTOM PROPERTIES declared in the above <properties> part -->
               <!-- something like :
               <my.custom.property>${my.custom.property}</my.custom.property>


### PR DESCRIPTION
…ime.

Backport of [CAMEL-16460] The Content-Language of CxfRsProducer should be configurable
(cherry picked from commits cf35b03b852a58ac5ca1bfc6a948b28fad7a841b and e96225adbabe8a70c64b8725908fdbe6b769dc44)