### PR TITLE
fix(TPRUN-4559) : Fix DefaultCxfRsBinding Content-Language header

### DIFF
--- a/components/camel-cxf/src/main/java/org/apache/camel/component/cxf/jaxrs/DefaultCxfRsBinding.java
+++ b/components/camel-cxf/src/main/java/org/apache/camel/component/cxf/jaxrs/DefaultCxfRsBinding.java
@@ -266,7 +266,7 @@ public class DefaultCxfRsBinding implements CxfRsBinding, HeaderFilterStrategyAw
             contentType = MediaType.WILDCARD;
         }
         String contentEncoding = camelMessage.getHeader(Exchange.CONTENT_ENCODING, String.class);
-        if (webClient != null && contentLanguage == null) {
+        if (webClient != null) {
             try {
                 Method getStateMethod = AbstractClient.class.getDeclaredMethod("getState");
                 getStateMethod.setAccessible(true);
@@ -286,8 +286,10 @@ public class DefaultCxfRsBinding implements CxfRsBinding, HeaderFilterStrategyAw
                         ex);
             }
         }
-        contentLanguage = Locale.US.getLanguage();
-        return Entity.entity(body, new Variant(MediaType.valueOf(contentType), Locale.US, contentEncoding));
+        if (contentLanguage == null) {
+            contentLanguage = Locale.US.getLanguage();
+        }
+        return Entity.entity(body, new Variant(MediaType.valueOf(contentType), new Locale(contentLanguage), contentEncoding));
     }
 
     /**

--- a/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/jaxrs/DefaultCxfRsBindingTest.java
+++ b/components/camel-cxf/src/test/java/org/apache/camel/component/cxf/jaxrs/DefaultCxfRsBindingTest.java
@@ -17,10 +17,15 @@
 package org.apache.camel.component.cxf.jaxrs;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.HttpHeaders;
 
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
@@ -29,6 +34,7 @@ import org.apache.camel.support.DefaultExchange;
 import org.apache.camel.support.DefaultHeaderFilterStrategy;
 import org.apache.camel.support.DefaultMessage;
 import org.apache.camel.support.ExchangeHelper;
+import org.apache.cxf.jaxrs.client.WebClient;
 import org.apache.cxf.message.MessageImpl;
 import org.junit.jupiter.api.Test;
 
@@ -71,4 +77,38 @@ public class DefaultCxfRsBindingTest {
         assertNull(camelMessage.getHeader("zeroSizeList"), "We should get nothing here");
     }
 
+    @Test
+    public void testContentLanguage() throws Exception {
+        DefaultCxfRsBinding cxfRsBinding = new DefaultCxfRsBinding();
+        cxfRsBinding.setHeaderFilterStrategy(new DefaultHeaderFilterStrategy());
+        Exchange exchange = new DefaultExchange(context);
+        Message camelMessage = new DefaultMessage(context);
+
+        Map<String, List<String>> headers = new HashMap<>();
+        headers.put(HttpHeaders.CONTENT_LANGUAGE, Arrays.asList(Locale.US.getLanguage()));
+
+        Entity<Object> entity0 = cxfRsBinding.bindCamelMessageToRequestEntity("body", camelMessage, exchange, null);
+        assertEquals(Locale.US.getLanguage(), entity0.getLanguage().getLanguage());
+
+        WebClient deWebClient = WebClient.create("http://localhost");
+        deWebClient.header(HttpHeaders.CONTENT_LANGUAGE, Locale.GERMAN.getLanguage());
+
+        Entity<Object> entity = cxfRsBinding.bindCamelMessageToRequestEntity("body", camelMessage, exchange, deWebClient);
+        assertEquals(Locale.GERMAN.getLanguage(), entity.getLanguage().getLanguage());
+
+        Entity<Object> entity2 = cxfRsBinding.bindCamelMessageToRequestEntity("body", camelMessage, exchange, deWebClient);
+        assertEquals(Locale.GERMAN.getLanguage(), entity2.getLanguage().getLanguage());
+
+        Entity<Object> entity3 = cxfRsBinding.bindCamelMessageToRequestEntity("body", camelMessage, exchange, null);
+        assertEquals(Locale.GERMAN.getLanguage(), entity3.getLanguage().getLanguage());
+
+        //check that if a new webclient with a different language
+
+        WebClient frWebClient = WebClient.create("http://localhost");
+        frWebClient.header(HttpHeaders.CONTENT_LANGUAGE, Locale.FRANCE.getLanguage());
+
+        Entity<Object> entity4 = cxfRsBinding.bindCamelMessageToRequestEntity("body", camelMessage, exchange, frWebClient);
+        assertEquals(Locale.FRANCE.getLanguage(), entity4.getLanguage().getLanguage());
+
+    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@
         <upstream.version>3.11.1</upstream.version>
         <camel-main.tesb.version>3.11.1.tesb1</camel-main.tesb.version>
         <camel-base-engine.tesb.version>3.11.1.tesb1</camel-base-engine.tesb.version>
-        <camel-cxf.tesb.version>3.11.1.20220121</camel-cxf.tesb.version>
+        <camel-cxf.tesb.version>3.11.1.20221020</camel-cxf.tesb.version>
         <camel-google-pubsub.tesb.version>3.11.1.20220926</camel-google-pubsub.tesb.version>
         <camel-grpc.tesb.version>3.11.1.20220926</camel-grpc.tesb.version>
 


### PR DESCRIPTION
DefautCxfRSBinding was initializing the response header from the first request ,and next times using Locale.US  .
New implementation :
- use Locale.US if nothing is set
- use the header Content-Language from the webClient if it is present (not just the first time)
- use the cached Content-Language header if not null and if webClient is null

New unit tests have been added.