### PR TITLE
TPRUN-5341 TPRUN-5600 TPRUN-5629 TPRUN-5630 Updates of vulnerable dependencies.

### DIFF
--- a/platforms/karaf/features/src/main/resources/features.xml
+++ b/platforms/karaf/features/src/main/resources/features.xml
@@ -1973,8 +1973,8 @@
     <bundle dependency='true'>mvn:commons-codec/commons-codec/${commons-codec.tesb.version}</bundle>
     <bundle dependency='true'>mvn:org.apache.httpcomponents/httpcore-osgi/${httpcore4-version}</bundle>
     <bundle dependency='true'>mvn:org.apache.httpcomponents/httpclient-osgi/${httpclient4-version}</bundle>
-    <bundle dependency='true'>mvn:https://maven.restlet.com@id=restlet!org.restlet.osgi/org.restlet/${restlet-version}</bundle>
-    <bundle dependency='true'>mvn:https://maven.restlet.com@id=restlet!org.restlet.osgi/org.restlet.ext.httpclient/${restlet-version}</bundle>
+    <bundle dependency='true'>mvn:https://maven.restlet.talend.com/@id=restlet!org.restlet.osgi/org.restlet/${restlet-version}</bundle>
+    <bundle dependency='true'>mvn:https://maven.restlet.talend.com/@id=restlet!org.restlet.osgi/org.restlet.ext.httpclient/${restlet-version}</bundle>
     <bundle dependency='true'>mvn:javax.servlet/javax.servlet-api/${javax.servlet-api-version}</bundle>
     <bundle>mvn:org.apache.camel/camel-http-common/${upstream.version}</bundle>
     <bundle>mvn:org.apache.camel/camel-restlet/${upstream.version}</bundle>
@@ -1993,13 +1993,13 @@
     <bundle dependency='true'>mvn:com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/${jackson2.tesb.version}</bundle>
     <bundle dependency='true'>mvn:com.fasterxml.jackson.module/jackson-module-jaxb-annotations/${jackson2.tesb.version}</bundle>
     <bundle dependency='true'>mvn:com.fasterxml.jackson.module/jackson-module-jsonSchema/${jackson2.tesb.version}</bundle>
-    <bundle>mvn:https://maven.restlet.com@id=restlet!org.restlet.osgi/org.restlet.ext.jackson/${restlet-version}</bundle>
+    <bundle>mvn:https://maven.restlet.talend.com/@id=restlet!org.restlet.osgi/org.restlet.ext.jackson/${restlet-version}</bundle>
   </feature>
   <feature name='camel-restlet-gson' version='${upstream.version}' resolver='(obr)' start-level='50'>
     <feature version='${upstream.version}'>camel-restlet</feature>
     <bundle dependency='true'>mvn:joda-time/joda-time/${jodatime2-bundle-version}</bundle>
     <bundle dependency='true'>mvn:com.google.code.gson/gson/${gson-version}</bundle>
-    <bundle>mvn:https://maven.restlet.com@id=restlet!org.restlet.osgi/org.restlet.ext.gson/${restlet-version}</bundle>
+    <bundle>mvn:https://maven.restlet.talend.com/@id=restlet!org.restlet.osgi/org.restlet.ext.gson/${restlet-version}</bundle>
   </feature>
   <feature name='camel-rest-swagger' version='${upstream.version}' resolver='(obr)' start-level='50'>
     <feature version='${upstream.version}'>camel-core</feature>

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
 
     <properties>
         <upstream.version>2.25.4</upstream.version>
-        <apache-camel.features.tesb.version>2.25.4.tesb7</apache-camel.features.tesb.version>
+        <apache-camel.features.tesb.version>2.25.4.tesb8</apache-camel.features.tesb.version>
         <hibernate-validator.tesb.version>6.0.17.Final</hibernate-validator.tesb.version>
         <camel-mqtt.tesb.version>2.25.4.20220513</camel-mqtt.tesb.version>
         <camel-cxf.tesb.version>2.25.4.20220513</camel-cxf.tesb.version>
@@ -58,15 +58,15 @@
         <shiro.tesb.version>1.8.0</shiro.tesb.version>
         <reactive-streams.tesb.version>1.0.3</reactive-streams.tesb.version>
         <netty-reactive-streams.tesb.version>2.0.5</netty-reactive-streams.tesb.version>
-        <netty.tesb.version>4.1.85.Final</netty.tesb.version>
+        <netty.tesb.version>4.1.86.Final</netty.tesb.version>
         <async-http-client-netty-utils.tesb.version>2.12.1</async-http-client-netty-utils.tesb.version>
-        <json-smart.tesb.version>2.4.7</json-smart.tesb.version>
-        <json-accessors-smart.tesb.version>2.4.2</json-accessors-smart.tesb.version>
+        <json-smart.tesb.version>2.4.9</json-smart.tesb.version>
+        <json-accessors-smart.tesb.version>2.4.9</json-accessors-smart.tesb.version>
         <asm.tesb.version>8.0.1</asm.tesb.version>
         <commons-io.tesb.version>2.8.0</commons-io.tesb.version>
         <commons-codec.tesb.version>1.15</commons-codec.tesb.version>
         <commons-compress.tesb.version>1.21</commons-compress.tesb.version>
-        <xstream-bundle.tesb.version>1.4.19_1</xstream-bundle.tesb.version>
+        <xstream-bundle.tesb.version>1.4.20_1</xstream-bundle.tesb.version>
         <jetty.tesb.version>9.4.49.v20220914</jetty.tesb.version>
         <xmlsec.tesb.version>2.1.7</xmlsec.tesb.version>
         <ant-bundle.tesb.version>1.10.12_1</ant-bundle.tesb.version>
@@ -77,7 +77,7 @@
         <jclouds.tesb.version>2.1.2</jclouds.tesb.version>
         <pax-cdi.tesb.version>1.1.4</pax-cdi.tesb.version>
         <tika.tesb.version>1.28.4</tika.tesb.version>
-        <jettison.tesb.version>1.5.3</jettison.tesb.version>
+        <jettison.tesb.version>1.5.4</jettison.tesb.version>
         <commons-text.tesb.version>1.10.0</commons-text.tesb.version>
 
         <!-- enforce to require using at least this maven version -->


### PR DESCRIPTION
Netty to 4.1.86.Final
CVE-2022-41966 Xstream to 1.4.20
CVE-2023-1430 Jettison to 1.5.4
CVE-2023-1370 json-smart to 2.4.9