### PR TITLE
fix(TPRUN-6139) json-smart stack exhaustion vulnerability | CVE-2023-1370

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
 
     <properties>
         <upstream.version>2.25.4</upstream.version>
-        <apache-camel.features.tesb.version>2.25.4.tesb10</apache-camel.features.tesb.version>
+        <apache-camel.features.tesb.version>2.25.4.tesb11</apache-camel.features.tesb.version>
         <hibernate-validator.tesb.version>6.0.17.Final</hibernate-validator.tesb.version>
         <camel-mqtt.tesb.version>2.25.4.20220513</camel-mqtt.tesb.version>
         <camel-cxf.tesb.version>2.25.4.20220513</camel-cxf.tesb.version>
@@ -60,7 +60,7 @@
         <netty-reactive-streams.tesb.version>2.0.5</netty-reactive-streams.tesb.version>
         <netty.tesb.version>4.1.86.Final</netty.tesb.version>
         <async-http-client-netty-utils.tesb.version>2.12.1</async-http-client-netty-utils.tesb.version>
-        <json-smart.tesb.version>2.4.9</json-smart.tesb.version>
+        <json-smart.tesb.version>2.4.10</json-smart.tesb.version>
         <json-accessors-smart.tesb.version>2.4.9</json-accessors-smart.tesb.version>
         <asm.tesb.version>8.0.1</asm.tesb.version>
         <commons-io.tesb.version>2.8.0</commons-io.tesb.version>


### PR DESCRIPTION
🏁 **Context**
- [TPRUN-6139](https://jira.talendforge.org/browse/TPRUN-6139)

🔍 **What is the problem this PR is trying to solve?**
Stack exhaustion vulnerability found in json-smart. Although the current version is intended as a fix for the vulnerability, an upgrade to version 2.4.10 is recommended

🚀 **What is the chosen solution to this problem?**
Bump-up json-smart version

🎾 **Impacts**

- [ ] **This PR introduces a breaking change**

**Dear contributor, please check if the PR fulfills these requirements**

- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR