### PR TITLE
TPRUN-7476 Fix Apache Camel CVEs in CQL and SQL components

### DIFF
--- a/Jenkinsfile.talend
+++ b/Jenkinsfile.talend
@@ -1,5 +1,5 @@
 @Library('esb') _
  
 Fork(
-        MVN_MODULES: 'org.apache.camel:camel-support,org.apache.camel:camel-activemq,org.apache.camel:camel-cxf-soap,org.apache.camel:camel-cxf-rest,org.apache.camel:camel-google-pubsub,org.apache.camel:camel-zookeeper,org.apache.camel:camel-zookeeper-master'
+        MVN_MODULES: 'org.apache.camel:camel-support,org.apache.camel:camel-activemq,org.apache.camel:camel-cxf-soap,org.apache.camel:camel-cxf-rest,org.apache.camel:camel-google-pubsub,org.apache.camel:camel-zookeeper,org.apache.camel:camel-zookeeper-master,org.apache.camel:camel-cassandraql,org.apache.camel:camel-sql'
 )

--- a/components/camel-cassandraql/pom.xml
+++ b/components/camel-cassandraql/pom.xml
@@ -29,9 +29,14 @@
 
     <artifactId>camel-cassandraql</artifactId>
     <packaging>jar</packaging>
+    <version>${revision}</version>
 
     <name>Camel :: Cassandra CQL</name>
     <description>Cassandra CQL3 support</description>
+
+    <properties>
+        <revision>${camel-cassandraql.tesb.version}</revision>
+    </properties>
 
     <dependencies>
 

--- a/components/camel-cassandraql/src/generated/resources/org/apache/camel/component/cassandra/cql.json
+++ b/components/camel-cassandraql/src/generated/resources/org/apache/camel/component/cassandra/cql.json
@@ -11,7 +11,7 @@
     "supportLevel": "Stable",
     "groupId": "org.apache.camel",
     "artifactId": "camel-cassandraql",
-    "version": "3.20.6-SNAPSHOT",
+    "version": "3.20.6.20240122",
     "scheme": "cql",
     "extendsScheme": "",
     "syntax": "cql:beanRef:hosts:port\/keyspace",

--- a/components/camel-cassandraql/src/main/docs/cql-component.adoc
+++ b/components/camel-cassandraql/src/main/docs/cql-component.adoc
@@ -186,6 +186,10 @@ Alternatively, the `CassandraAggregationRepository` does not have a
 `LOCAL_QUORUM`…
 |=======================================================================
 
+While deserializing it's important to notice that the the unmarshallExchange method will allow only all java packages and subpackages
+and org.apache.camel packages and subpackages. The remaining classes will be blacklisted. So you'll need to change the filter in case of need.
+This could be accomplished by changing the deserializationFilter field on the repository.
+
 == Examples
 
 To insert something on a table you can use the following code:

--- a/components/camel-cassandraql/src/main/java/org/apache/camel/processor/aggregate/cassandra/CassandraAggregationRepository.java
+++ b/components/camel-cassandraql/src/main/java/org/apache/camel/processor/aggregate/cassandra/CassandraAggregationRepository.java
@@ -121,6 +121,14 @@ public class CassandraAggregationRepository extends ServiceSupport implements Re
 
     private boolean allowSerializedHeaders;
 
+    /**
+     * Sets a deserialization filter while reading Object from Aggregation Repository. By default the filter will allow
+     * all java packages and subpackages and all org.apache.camel packages and subpackages, while the remaining will be
+     * blacklisted and not deserialized. This parameter should be customized if you're using classes you trust to be
+     * deserialized.
+     */
+    private String deserializationFilter = "java.**;org.apache.camel.**;!*";
+
     public CassandraAggregationRepository() {
     }
 
@@ -211,7 +219,8 @@ public class CassandraAggregationRepository extends ServiceSupport implements Re
         Exchange exchange = null;
         if (row != null) {
             try {
-                exchange = exchangeCodec.unmarshallExchange(camelContext, row.getByteBuffer(exchangeColumn));
+                exchange = exchangeCodec.unmarshallExchange(camelContext, row.getByteBuffer(exchangeColumn),
+                        deserializationFilter);
             } catch (IOException iOException) {
                 throw new CassandraAggregationException("Failed to read exchange", exchange, iOException);
             } catch (ClassNotFoundException classNotFoundException) {
@@ -467,5 +476,13 @@ public class CassandraAggregationRepository extends ServiceSupport implements Re
 
     public void setAllowSerializedHeaders(boolean allowSerializedHeaders) {
         this.allowSerializedHeaders = allowSerializedHeaders;
+    }
+
+    public String getDeserializationFilter() {
+        return deserializationFilter;
+    }
+
+    public void setDeserializationFilter(String deserializationFilter) {
+        this.deserializationFilter = deserializationFilter;
     }
 }

--- a/components/camel-cassandraql/src/main/java/org/apache/camel/processor/aggregate/cassandra/CassandraCamelCodec.java
+++ b/components/camel-cassandraql/src/main/java/org/apache/camel/processor/aggregate/cassandra/CassandraCamelCodec.java
@@ -16,11 +16,7 @@
  */
 package org.apache.camel.processor.aggregate.cassandra;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
+import java.io.*;
 import java.nio.ByteBuffer;
 
 import org.apache.camel.CamelContext;
@@ -63,9 +59,10 @@ public class CassandraCamelCodec {
         return ByteBuffer.wrap(serialize(pe));
     }
 
-    public Exchange unmarshallExchange(CamelContext camelContext, ByteBuffer buffer)
+    public Exchange unmarshallExchange(CamelContext camelContext, ByteBuffer buffer, String deserializationFilter)
             throws IOException, ClassNotFoundException {
-        DefaultExchangeHolder pe = (DefaultExchangeHolder) deserialize(camelContext, new ByteBufferInputStream(buffer));
+        DefaultExchangeHolder pe
+                = (DefaultExchangeHolder) deserialize(camelContext, new ByteBufferInputStream(buffer), deserializationFilter);
         Exchange answer = new DefaultExchange(camelContext);
         DefaultExchangeHolder.unmarshal(answer, pe);
         // restore the from endpoint
@@ -87,9 +84,11 @@ public class CassandraCamelCodec {
         return bytesOut.toByteArray();
     }
 
-    private Object deserialize(CamelContext camelContext, InputStream bytes) throws IOException, ClassNotFoundException {
+    private Object deserialize(CamelContext camelContext, InputStream bytes, String deserializationFilter)
+            throws IOException, ClassNotFoundException {
         ClassLoader classLoader = camelContext.getApplicationContextClassLoader();
         ObjectInputStream objectIn = new ClassLoadingAwareObjectInputStream(classLoader, bytes);
+        objectIn.setObjectInputFilter(ObjectInputFilter.Config.createFilter(deserializationFilter));
         Object object = objectIn.readObject();
         objectIn.close();
         return object;

--- a/components/camel-cassandraql/src/test/java/org/apache/camel/processor/aggregate/cassandra/CassandraCamelCodecTest.java
+++ b/components/camel-cassandraql/src/test/java/org/apache/camel/processor/aggregate/cassandra/CassandraCamelCodecTest.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.processor.aggregate.cassandra;
+
+import java.io.*;
+import java.nio.ByteBuffer;
+
+import org.apache.camel.test.junit5.CamelTestSupport;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.malicious.example.Employee;
+
+public class CassandraCamelCodecTest extends CamelTestSupport {
+
+    CassandraCamelCodec codec;
+
+    @Override
+    protected void startCamelContext() throws Exception {
+        super.startCamelContext();
+        codec = new CassandraCamelCodec();
+    }
+
+    @Test
+    public void shouldFailWithRejected() throws IOException, ClassNotFoundException {
+        Employee emp = new Employee("Mickey", "Mouse");
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        ObjectOutputStream oos = new ObjectOutputStream(baos);
+
+        oos.writeObject(emp);
+
+        oos.flush();
+        oos.close();
+
+        InputStream is = new ByteArrayInputStream(baos.toByteArray());
+        InvalidClassException thrown = Assertions.assertThrows(InvalidClassException.class, () -> {
+            codec.unmarshallExchange(context, ByteBuffer.wrap(is.readAllBytes()), "java.**;org.apache.camel.**;!*");
+        });
+
+        Assertions.assertEquals("filter status: REJECTED", thrown.getMessage());
+    }
+}

--- a/components/camel-cassandraql/src/test/java/org/malicious/example/Employee.java
+++ b/components/camel-cassandraql/src/test/java/org/malicious/example/Employee.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.malicious.example;
+
+import java.io.Serializable;
+
+public class Employee implements Serializable {
+
+    String name;
+    String surname;
+
+    public Employee(String name, String surname) {
+        this.name = name;
+        this.surname = surname;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getSurname() {
+        return surname;
+    }
+
+    public void setSurname(String surname) {
+        this.surname = surname;
+    }
+}

--- a/components/camel-sql/pom.xml
+++ b/components/camel-sql/pom.xml
@@ -30,8 +30,10 @@
     <packaging>jar</packaging>
     <name>Camel :: SQL</name>
     <description>Camel SQL support</description>
+    <version>${revision}</version>
 
     <properties>
+        <revision>${camel-sql.tesb.version}</revision>
         <camel.surefire.parallel>true</camel.surefire.parallel>
     </properties>
 

--- a/components/camel-sql/src/generated/resources/org/apache/camel/component/sql/sql.json
+++ b/components/camel-sql/src/generated/resources/org/apache/camel/component/sql/sql.json
@@ -11,7 +11,7 @@
     "supportLevel": "Stable",
     "groupId": "org.apache.camel",
     "artifactId": "camel-sql",
-    "version": "3.20.6-SNAPSHOT",
+    "version": "3.20.6.20240122",
     "scheme": "sql",
     "extendsScheme": "",
     "syntax": "sql:query",

--- a/components/camel-sql/src/generated/resources/org/apache/camel/component/sql/stored/sql-stored.json
+++ b/components/camel-sql/src/generated/resources/org/apache/camel/component/sql/stored/sql-stored.json
@@ -11,7 +11,7 @@
     "supportLevel": "Stable",
     "groupId": "org.apache.camel",
     "artifactId": "camel-sql",
-    "version": "3.20.6-SNAPSHOT",
+    "version": "3.20.6.20240122",
     "scheme": "sql-stored",
     "extendsScheme": "",
     "syntax": "sql-stored:template",

--- a/components/camel-sql/src/main/docs/sql-component.adoc
+++ b/components/camel-sql/src/main/docs/sql-component.adoc
@@ -594,6 +594,10 @@ the `currentThread` one. The benefit is to be able to load classes
 exposed by other bundles. This allows the exchange body and headers to
 have custom types object references.
 
+While deserializing it's important to notice that the decode function and the unmarshallExchange method will allow only all java packages and subpackages 
+and org.apache.camel packages and subpackages. The remaining classes will be blacklisted. So you'll need to change the filter in case of need. 
+This could be accomplished by changing the deserializationFilter field on the repository.
+
 === Transaction
 
 A Spring `PlatformTransactionManager` is required to orchestrate

--- a/components/camel-sql/src/main/java/org/apache/camel/processor/aggregate/jdbc/JdbcAggregationRepository.java
+++ b/components/camel-sql/src/main/java/org/apache/camel/processor/aggregate/jdbc/JdbcAggregationRepository.java
@@ -94,6 +94,7 @@ public class JdbcAggregationRepository extends ServiceSupport
     private String deadLetterUri;
     private List<String> headersToStoreAsText;
     private boolean storeBodyAsText;
+    private String deserializationFilter = "java.**;org.apache.camel.**;!*";
 
     /**
      * Creates an aggregation repository
@@ -357,7 +358,7 @@ public class JdbcAggregationRepository extends ServiceSupport
                         version = (long) versionObj;
                     }
 
-                    Exchange result = codec.unmarshallExchange(camelContext, marshalledExchange);
+                    Exchange result = codec.unmarshallExchange(camelContext, marshalledExchange, deserializationFilter);
                     result.setProperty(VERSION_PROPERTY, version);
                     return result;
 
@@ -624,6 +625,20 @@ public class JdbcAggregationRepository extends ServiceSupport
 
     public String getRepositoryNameCompleted() {
         return getRepositoryName() + "_completed";
+    }
+
+    public String getDeserializationFilter() {
+        return deserializationFilter;
+    }
+
+    /**
+     * Sets a deserialization filter while reading Object from Aggregation Repository. By default the filter will allow
+     * all java packages and subpackages and all org.apache.camel packages and subpackages, while the remaining will be
+     * blacklisted and not deserialized. This parameter should be customized if you're using classes you trust to be
+     * deserialized.
+     */
+    public void setDeserializationFilter(String deserializationFilter) {
+        this.deserializationFilter = deserializationFilter;
     }
 
     @Override

--- a/components/camel-sql/src/main/java/org/apache/camel/processor/aggregate/jdbc/JdbcCamelCodec.java
+++ b/components/camel-sql/src/main/java/org/apache/camel/processor/aggregate/jdbc/JdbcCamelCodec.java
@@ -16,13 +16,7 @@
  */
 package org.apache.camel.processor.aggregate.jdbc;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
-import java.io.OutputStream;
+import java.io.*;
 
 import org.apache.camel.CamelContext;
 import org.apache.camel.Endpoint;
@@ -74,13 +68,14 @@ public class JdbcCamelCodec {
         encode(pe, outputStream);
     }
 
-    public Exchange unmarshallExchange(CamelContext camelContext, byte[] buffer) throws IOException, ClassNotFoundException {
-        return unmarshallExchange(camelContext, new ByteArrayInputStream(buffer));
+    public Exchange unmarshallExchange(CamelContext camelContext, byte[] buffer, String deserializationFilter)
+            throws IOException, ClassNotFoundException {
+        return unmarshallExchange(camelContext, new ByteArrayInputStream(buffer), deserializationFilter);
     }
 
-    public Exchange unmarshallExchange(CamelContext camelContext, InputStream inputStream)
+    public Exchange unmarshallExchange(CamelContext camelContext, InputStream inputStream, String deserializationFilter)
             throws IOException, ClassNotFoundException {
-        DefaultExchangeHolder pe = decode(camelContext, inputStream);
+        DefaultExchangeHolder pe = decode(camelContext, inputStream, deserializationFilter);
         Exchange answer = new DefaultExchange(camelContext);
         DefaultExchangeHolder.unmarshal(answer, pe);
         // restore the from endpoint
@@ -100,12 +95,13 @@ public class JdbcCamelCodec {
         }
     }
 
-    private DefaultExchangeHolder decode(CamelContext camelContext, InputStream bytesIn)
+    private DefaultExchangeHolder decode(CamelContext camelContext, InputStream bytesIn, String deserializationFilter)
             throws IOException, ClassNotFoundException {
         ObjectInputStream objectIn = null;
         Object obj = null;
         try {
             objectIn = new ClassLoadingAwareObjectInputStream(camelContext.getApplicationContextClassLoader(), bytesIn);
+            objectIn.setObjectInputFilter(ObjectInputFilter.Config.createFilter(deserializationFilter));
             obj = objectIn.readObject();
         } finally {
             IOHelper.close(objectIn);

--- a/components/camel-sql/src/test/java/org/apache/camel/processor/aggregate/jdbc/JdbcCamelCodecTest.java
+++ b/components/camel-sql/src/test/java/org/apache/camel/processor/aggregate/jdbc/JdbcCamelCodecTest.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.processor.aggregate.jdbc;
+
+import java.io.*;
+
+import org.apache.camel.test.junit5.CamelTestSupport;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.malicious.example.Employee;
+
+public class JdbcCamelCodecTest extends CamelTestSupport {
+
+    JdbcCamelCodec codec;
+
+    @Override
+    protected void startCamelContext() throws Exception {
+        super.startCamelContext();
+        codec = new JdbcCamelCodec();
+    }
+
+    @Test
+    public void shouldFailWithRejected() throws IOException, ClassNotFoundException {
+        Employee emp = new Employee("Mickey", "Mouse");
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        ObjectOutputStream oos = new ObjectOutputStream(baos);
+
+        oos.writeObject(emp);
+
+        oos.flush();
+        oos.close();
+
+        InputStream is = new ByteArrayInputStream(baos.toByteArray());
+        InvalidClassException thrown = Assertions.assertThrows(InvalidClassException.class, () -> {
+            codec.unmarshallExchange(context, is, "java.**;org.apache.camel.**;!*");
+        });
+
+        Assertions.assertEquals("filter status: REJECTED", thrown.getMessage());
+    }
+}

--- a/components/camel-sql/src/test/java/org/malicious/example/Employee.java
+++ b/components/camel-sql/src/test/java/org/malicious/example/Employee.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.malicious.example;
+
+import java.io.Serializable;
+
+public class Employee implements Serializable {
+
+    String name;
+    String surname;
+
+    public Employee(String name, String surname) {
+        this.name = name;
+        this.surname = surname;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getSurname() {
+        return surname;
+    }
+
+    public void setSurname(String surname) {
+        this.surname = surname;
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -106,9 +106,11 @@
         <upstream.version>3.20.6</upstream.version>
         <camel-support.tesb.version>3.20.6.20230530</camel-support.tesb.version>
         <camel-activemq.tesb.version>3.20.6.20230530</camel-activemq.tesb.version>
+        <camel-cassandraql.tesb.version>3.20.6.20240122</camel-cassandraql.tesb.version>
         <camel-cxf-soap.tesb.version>3.20.6.20230530</camel-cxf-soap.tesb.version>
         <camel-cxf-rest.tesb.version>3.20.6.20230530</camel-cxf-rest.tesb.version>
         <camel-google-pubsub.tesb.version>3.20.6.20230530</camel-google-pubsub.tesb.version>
+        <camel-sql.tesb.version>3.20.6.20240122</camel-sql.tesb.version>
         <camel-zookeeper.tesb.version>3.20.6.20230530</camel-zookeeper.tesb.version>
         <camel-zookeeper-master.tesb.version>3.20.6.20230530</camel-zookeeper-master.tesb.version>
         <zookeeper.tesb.version>3.7.1</zookeeper.tesb.version>
@@ -275,9 +277,11 @@
                             -->
                             <camel-support.tesb.version>${camel-support.tesb.version}</camel-support.tesb.version>
                             <camel-activemq.tesb.version>${camel-activemq.tesb.version}</camel-activemq.tesb.version>
+                            <camel-cassandraql.tesb.version>${camel-cassandraql.tesb.version}</camel-cassandraql.tesb.version>
                             <camel-cxf-soap.tesb.version>${camel-cxf-soap.tesb.version}</camel-cxf-soap.tesb.version>
                             <camel-cxf-rest.tesb.version>${camel-cxf-rest.tesb.version}</camel-cxf-rest.tesb.version>
                             <camel-google-pubsub.tesb.version>${camel-google-pubsub.tesb.version}</camel-google-pubsub.tesb.version>
+                            <camel-sql.tesb.version>${camel-sql.tesb.version}</camel-sql.tesb.version>
                             <camel-zookeeper.tesb.version>${camel-zookeeper.tesb.version}</camel-zookeeper.tesb.version>
                             <camel-zookeeper-master.tesb.version>${camel-zookeeper-master.tesb.version}</camel-zookeeper-master.tesb.version>
                             <zookeeper.tesb.version>${zookeeper.tesb.version}</zookeeper.tesb.version>


### PR DESCRIPTION
Fixes https://jira.talendforge.org/browse/TPRUN-7476

## Motivation

There are known CVEs in Apache Camel that have been fixed in all still supported versions but since 3.20 is no longer supported, the fixes need to be applied to our fork.

## Modifications:

* Applied fixes for CAMEL-20303 and CAMEL-20306 