### PR TITLE
fix(DPE-1805): re-add CXF Jetty blueprint xmlns handler in camel-karaf

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@
         <camel-support.tesb.version>4.8.1.20250320</camel-support.tesb.version>
         <camel-activemq.tesb.version>4.8.1.20250320</camel-activemq.tesb.version>
         <camel-activemq6.tesb.version>4.8.1.20250320</camel-activemq6.tesb.version>
-        <camel-cxf.tesb.version>4.8.1.20250320</camel-cxf.tesb.version>
+        <camel-cxf.tesb.version>4.8.1.20250922</camel-cxf.tesb.version>
         <camel-cxf-soap.tesb.version>4.8.1.20250320</camel-cxf-soap.tesb.version>
         <camel-cxf-rest.tesb.version>4.8.1.20250320</camel-cxf-rest.tesb.version>
         <camel-spring.tesb.version>4.8.1.20250320</camel-spring.tesb.version>

--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@
         <camel-support.tesb.version>4.8.1.20250320</camel-support.tesb.version>
         <camel-activemq.tesb.version>4.8.1.20250320</camel-activemq.tesb.version>
         <camel-activemq6.tesb.version>4.8.1.20250320</camel-activemq6.tesb.version>
-        <camel-cxf.tesb.version>4.8.1.20250922</camel-cxf.tesb.version>
+        <camel-cxf.tesb.version>4.8.1.20251001</camel-cxf.tesb.version>
         <camel-cxf-soap.tesb.version>4.8.1.20250320</camel-cxf-soap.tesb.version>
         <camel-cxf-rest.tesb.version>4.8.1.20250320</camel-cxf-rest.tesb.version>
         <camel-spring.tesb.version>4.8.1.20250320</camel-spring.tesb.version>


### PR DESCRIPTION
🏁 **Context**
- [DPE-1805](https://qlik-dev.atlassian.net/browse/DPE-1805)

🔍 **What is the problem this PR is trying to solve?**
Blueprint files cannot properly use the CXF Jetty xmlns because there is no handler. Currently, installed handler is for Spring.

🚀 **What is the chosen solution to this problem?**
Port a recent commit from the official `camel-karaf` repo where the CXF Jetty blueprint xmlns handler was re-added.
Set the Blueprint handler for CXF Jetty xmlns as the default one.

🎾 **Impacts**
- [ ] **This PR introduces a breaking change**

**Dear contributor, please check if the PR fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR
